### PR TITLE
Fixed an issue that caused longer game names to be unselectable (Fixes #43, Fixes #47)

### DIFF
--- a/Stream.py
+++ b/Stream.py
@@ -12,6 +12,7 @@ class Stream:
     def search(self, game):
         if not game:
             return []
+        game = game[:25] # If the game name exceeds 25 characters, the API will return error 500
         url = f"https://streamlabs.com/api/v5/slobs/tiktok/info?category={game}"
         info = self.s.get(url).json()
         info["categories"].append({"full_name": "Other", "game_mask_id": ""})


### PR DESCRIPTION
## Description

Fixed an issue where the StreamLabs API would return error 500 when searching for games with names longer than 25 characters. 

The fix involves truncating the game name to 25 characters before making the API call. This works because even with the truncated search term, the full game still appears in the returned list of games, allowing us to fetch the correct game ID.

### Example
- Search term: "Life is Strange: Before the Storm" (33 chars)
- Truncated to: "Life is Strange: Before t" (25 chars)
- API returns successful response including the full game in results
- Correct game ID is fetched from the returned list (Since the full name is still used to select it)

#### This resolves the game selection errors reported in issues
- #43 
- #47 